### PR TITLE
Downgrade Skia library because of dependency with Syncfusion

### DIFF
--- a/Directory.Packages.Default.props
+++ b/Directory.Packages.Default.props
@@ -224,11 +224,11 @@
     <PackageVersion Include="ShellProgressBar"                                        Version="5.2.0" />            <!-- netstandard -->
     <PackageVersion Include="SixLabors.ImageSharp"                                    Version="3.1.6" />            <!-- net6 -->
     <PackageVersion Include="SixLabors.ImageSharp.Drawing"                            Version="2.1.5" />            <!-- net6 -->
-    <PackageVersion Include="SkiaSharp"                                               Version="3.116.1" />          <!-- netstandard, net6, net8 -->
-    <PackageVersion Include="SkiaSharp.NativeAssets.Linux"                            Version="3.116.1" />          <!-- netstandard, net6, net8 -->
-    <PackageVersion Include="SkiaSharp.NativeAssets.Linux.NoDependencies"             Version="3.116.1" />          <!-- netstandard, net6, net8 -->
-    <PackageVersion Include="SkiaSharp.Views.Blazor"                                  Version="3.116.1" />          <!-- net6, net8 -->
-
+    <PackageVersion Include="SkiaSharp"                                               Version="2.88.9" />           <!-- netstandard, net6 -->
+    <PackageVersion Include="SkiaSharp.NativeAssets.Linux"                            Version="2.88.9" />           <!-- netstandard, net6 -->
+    <PackageVersion Include="SkiaSharp.NativeAssets.Linux.NoDependencies"             Version="2.88.9" />           <!-- netstandard, net6 -->
+    <PackageVersion Include="SkiaSharp.Views.Blazor"                                  Version="2.88.9" />           <!-- net6 -->
+	
     <PackageVersion Include="SonarAnalyzer.CSharp"                                    Version="10.4.0.108396" />    <!-- NO DEPS -->
     <PackageVersion Include="Spire.PDF"                                               Version="10.11.1" />          <!-- net6 -->
     <PackageVersion Include="StyleCop.Analyzers"                                      Version="1.1.118" />          <!-- NO DEPS -->


### PR DESCRIPTION
With the version 3.116.1, an error occur when _William_ use the library to generate a pdf :
```
System.MissingMethodException: Method not found: 'SkiaSharp.SKTypeface SkiaSharp.SKTypeface.FromFamilyName(System.String, SkiaSharp.SKTypefaceStyle)'.
   at Syncfusion.Drawing.SkiaSharpHelper.FontExtension.GetTypeface(String fontName, FontStyle style, Boolean& hasStylesAndWeights)
   at Syncfusion.Drawing.SkiaSharpHelper.FontExtension.InitializeSkiaSharpProperties(String fontName, Single fontSize, FontStyle style, GraphicsUnit unit, Boolean& hasStylesAndWeights)
   at Syncfusion.DocIORenderer.RenderHelper.GetFontName(String fontName, Single fontSize, FontStyle fontStyle, FontScriptType scriptType, Boolean& hasStylesAndWeights)
```