### PR TITLE
fix(tasks): make Lock/Unlock work cross-platform via lock file

### DIFF
--- a/Tasks/Source/Lock.cs
+++ b/Tasks/Source/Lock.cs
@@ -64,7 +64,7 @@ namespace Zou.Tasks
                 try
                 {
                     // FileShare.None denies any concurrent open: a second process
-                    // (or build node) blocks here until the holder releases.
+                    // (or build node) gets an IOException and retries until release.
                     return new FileStream(path, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None);
                 }
                 catch (IOException)

--- a/Tasks/Source/Lock.cs
+++ b/Tasks/Source/Lock.cs
@@ -2,7 +2,10 @@
 // Author: Roger VUISTINER, Maintainer: Roger VUISTINER
 
 using System;
-using System.Runtime.InteropServices;
+using System.Diagnostics;
+using System.IO;
+using System.Security.Cryptography;
+using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
 
@@ -11,6 +14,12 @@ using Microsoft.Build.Utilities;
 
 namespace Zou.Tasks
 {
+    // Cross-process build lock based on an exclusively-opened lock file
+    // (FileShare.None). Unlike named semaphores -- which are Windows-only and
+    // throw PlatformNotSupportedException on Unix -- a lock file provides the
+    // same mutual exclusion on every platform MSBuild runs on, with a single
+    // code path. The acquired FileStream is kept open by the build engine and
+    // released by the matching Unlock task.
     public class Lock : Task
     {
         public bool                 Global  { get; set; }
@@ -19,33 +28,18 @@ namespace Zou.Tasks
 
         public override bool        Execute()
         {
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                // Unix does not support named semaphores (PlatformNotSupportedException)
-                return true;
-            }
             try
             {
-                string semName = Lock.GetName(this.Name, this.Global);
-                var sem = new Semaphore(1, 1, semName, out bool semCreated);
+                string lockPath = Lock.GetLockFilePath(this.Name, this.Global);
 
-                // Register the semaphore with the build engine:
-                // - to keep it alive until the end of the build (avoid GC)
-                // - optionnally to make it available for Unlock task.
-                this.RegisterSemaphore(semName, sem);
+                this.Log.LogMessageFromText($"Lock -> waiting lock '{lockPath}'.", MessageImportance.Normal);
+                var stream = Lock.AcquireLock(lockPath, this.TimeoutInternal);
 
-                this.Log.LogMessageFromText($"Lock -> waiting semaphore '{semName}', created = {semCreated}.", MessageImportance.Normal);
-                var hasSem = sem.WaitOne(this.TimeoutInternal);
-                if (hasSem)
-                {
-                    this.Log.LogMessageFromText($"Lock -> entered semaphore '{semName}', created = {semCreated}.", MessageImportance.Normal);
-                }
-                else
-                {
-                    throw new TimeoutException($"Lock -> timeout waiting for semaphore '{semName}'.");
-                }
-
-
+                // Register the stream with the build engine:
+                // - to keep the lock held (stream open) until the end of the build,
+                // - to make it available for the matching Unlock task.
+                this.RegisterLock(lockPath, stream);
+                this.Log.LogMessageFromText($"Lock -> entered lock '{lockPath}'.", MessageImportance.Normal);
             }
             catch (Exception e)
             {
@@ -55,20 +49,74 @@ namespace Zou.Tasks
         }
 
         private int                 TimeoutInternal => this.Timeout == 0 ? System.Threading.Timeout.Infinite : this.Timeout;
-        private void                RegisterSemaphore(string semName, Semaphore sem)
+        private void                RegisterLock(string key, FileStream stream)
         {
-            this.BuildEngine4.RegisterTaskObject(semName, sem, RegisteredTaskObjectLifetime.AppDomain, false);
+            this.BuildEngine4.RegisterTaskObject(key, stream, RegisteredTaskObjectLifetime.AppDomain, false);
         }
 
-        internal static string      GetName(string name, bool global)
+        private static FileStream   AcquireLock(string path, int timeoutMs)
         {
-            // Replace consecutive non-alphanumeric characters with underscore.
-            var semName = Regex.Replace(name, @"\W+", "_", RegexOptions.CultureInvariant).ToLowerInvariant();
-            if (global)
+            Directory.CreateDirectory(Path.GetDirectoryName(path));
+
+            var watch = Stopwatch.StartNew();
+            while (true)
             {
-                return "Global\\" + semName;
+                try
+                {
+                    // FileShare.None denies any concurrent open: a second process
+                    // (or build node) blocks here until the holder releases.
+                    return new FileStream(path, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None);
+                }
+                catch (IOException)
+                {
+                    if (timeoutMs != System.Threading.Timeout.Infinite && watch.ElapsedMilliseconds >= timeoutMs)
+                    {
+                        throw new TimeoutException($"Lock -> timeout waiting for lock file '{path}'.");
+                    }
+                    Thread.Sleep(Lock.PollIntervalMs);
+                }
             }
-            return semName;
         }
+
+        internal static string      GetLockFilePath(string name, bool global)
+        {
+            // A readable (but bounded) prefix derived from the lock name, plus a
+            // stable hash so distinct names never collide and the file-name
+            // component stays within filesystem limits even for long paths.
+            var safe = Regex.Replace(name, @"\W+", "_", RegexOptions.CultureInvariant).ToLowerInvariant();
+            if (safe.Length > 64)
+            {
+                safe = safe.Substring(0, 64);
+            }
+
+            // The Global flag maps to a distinct lock identity (kept for API
+            // parity with the former named-semaphore "Global\" namespace). Note
+            // the lock file lives under the per-user temp directory, which is
+            // sufficient for serializing parallel build nodes of a single user;
+            // it is not shared across user sessions. Global is currently unused
+            // by the build targets.
+            var hash = Lock.GetStableHash((global ? "G|" : "L|") + name);
+            var dir  = Path.Combine(Path.GetTempPath(), "zou-locks");
+            return Path.Combine(dir, $"{safe}.{hash}.lock");
+        }
+
+        private static string       GetStableHash(string value)
+        {
+            // SHA1 (not String.GetHashCode, which is per-process randomized and
+            // would yield different file names across processes) keeps the lock
+            // identity consistent for every process contending on it.
+            using (var sha1 = SHA1.Create())
+            {
+                var bytes = sha1.ComputeHash(Encoding.UTF8.GetBytes(value));
+                var sb    = new StringBuilder(16);
+                for (var i = 0; i < 8; i++)
+                {
+                    sb.Append(bytes[i].ToString("x2"));
+                }
+                return sb.ToString();
+            }
+        }
+
+        private const int           PollIntervalMs = 50;
     }
 }

--- a/Tasks/Source/Unlock.cs
+++ b/Tasks/Source/Unlock.cs
@@ -2,14 +2,16 @@
 // Author: Roger VUISTINER, Maintainer: Roger VUISTINER
 
 using System;
-using System.Runtime.InteropServices;
-using System.Threading;
+using System.IO;
 
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 
 namespace Zou.Tasks
 {
+    // Releases the cross-process lock acquired by the matching Lock task by
+    // disposing the FileStream kept alive in the build engine registry. See
+    // Lock for the rationale behind the lock-file approach.
     public class Unlock : Task
     {
         public bool                 Global { get; set; }
@@ -17,23 +19,21 @@ namespace Zou.Tasks
 
         public override bool        Execute()
         {
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                // Unix does not support named semaphores (PlatformNotSupportedException)
-                return true;
-            }
             try
             {
-                var semName = Lock.GetName(this.Name, this.Global);
-                var sem = this.GetRegisteredSemaphore(semName);
-                if (sem == null)
+                var lockPath = Lock.GetLockFilePath(this.Name, this.Global);
+                var stream   = this.UnregisterLock(lockPath);
+                if (stream == null)
                 {
-                    this.Log.LogError($"Unlock -> semaphore '{semName}' not registered.");
+                    this.Log.LogError($"Unlock -> lock '{lockPath}' not registered.");
                 }
                 else
                 {
-                    this.Log.LogMessageFromText($"Unlock -> released semaphore '{semName}'.", MessageImportance.Normal);
-                    sem.Release();
+                    // Disposing the stream closes the handle and releases the
+                    // FileShare.None lock; the lock file itself is left on disk
+                    // for reuse (harmless, and avoids delete/recreate races).
+                    stream.Dispose();
+                    this.Log.LogMessageFromText($"Unlock -> released lock '{lockPath}'.", MessageImportance.Normal);
                 }
             }
             catch (Exception e)
@@ -43,9 +43,9 @@ namespace Zou.Tasks
             return !this.Log.HasLoggedErrors;
         }
 
-        private Semaphore           GetRegisteredSemaphore(string name)
+        private FileStream          UnregisterLock(string key)
         {
-            return this.BuildEngine4.GetRegisteredTaskObject(name, RegisteredTaskObjectLifetime.AppDomain) as Semaphore;
+            return this.BuildEngine4.UnregisterTaskObject(key, RegisteredTaskObjectLifetime.AppDomain) as FileStream;
         }
     }
 }


### PR DESCRIPTION
The Lock/Unlock MSBuild tasks used a Windows named semaphore and silently no-op'd on Unix (named semaphores throw PlatformNotSupportedException), leaving builds with no mutual exclusion on Linux/macOS.

Replace the named semaphore with a single cross-platform mechanism: a lock file opened exclusively (FileShare.None), which provides the same mutual exclusion on every platform MSBuild runs on. This also removes the non-idiomatic RuntimeInformation.IsOSPlatform branch -- one code path now.

The acquired FileStream is kept in the build engine task-object registry between Lock and Unlock. The lock identity is a readable, length-bounded name plus a stable SHA1 hash (not the per-process-randomized GetHashCode) so contending processes agree on the same file.